### PR TITLE
fix bx{cond} instruction in ARM mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ hashtable.h
 *.exe
 capstone-3.0.5-rc2
 *.gba
+.fuse_hidden*


### PR DESCRIPTION
Before: 
```Assembly
	ARM_FUNC_START sub_80B1A60
sub_80B1A60: @ 0x080B1A60
	ldr r2, _080B1C1C
_080B1A64:
	add r2, r2, r1, lsl #3
	ldr r1, [r2]
	lsl r0, r0, #1
	ldrh r0, [r1, r0]
	cmp r0, #0x4000
	bxhs lr
_080B1A7C:
	.byte 0x04, 0x10, 0x92, 0xE5
	.byte 0x80, 0x00, 0xA0, 0xE1, 0xB0, 0x00, 0x91, 0xE1, 0x1E, 0xFF, 0x2F, 0xE1
```

After: 
```Assembly
	arm_func_start sub_80B1A60
sub_80B1A60: @ 0x080B1A60
	ldr r2, _080B1C1C
_080B1A64:
	add r2, r2, r1, lsl #3
	ldr r1, [r2]
	lsl r0, r0, #1
	ldrh r0, [r1, r0]
	cmp r0, #0x4000
	bxhs lr
	ldr r1, [r2, #4]
	lsl r0, r0, #1
	ldrh r0, [r1, r0]
	bx lr
```