### PR TITLE
fix/mitigate various issues

### DIFF
--- a/disasm.c
+++ b/disasm.c
@@ -8,6 +8,8 @@
 
 #include "gbadisasm.h"
 
+extern void fatal_error(const char *fmt, ...);
+
 uint32_t ROM_LOAD_ADDR;
 #define UNKNOWN_SIZE (uint32_t)-1
 
@@ -54,6 +56,8 @@ int disasm_add_label(uint32_t addr, uint8_t type, char *name)
 
     i = gLabelsCount++;
     gLabels = realloc(gLabels, gLabelsCount * sizeof(*gLabels));
+    if (gLabels == NULL)
+        fatal_error("failed to alloc space for labels. ");
     gLabels[i].addr = addr;
     gLabels[i].type = type;
     if (type == LABEL_ARM_CODE || type == LABEL_THUMB_CODE)

--- a/disasm.c
+++ b/disasm.c
@@ -610,16 +610,19 @@ static void print_insn(const cs_insn *insn, uint32_t addr, int mode)
             label_p = lookup_label(value);
             if (label_p != NULL)
             {
-                if (label_p->name != NULL)
-                    printf("\t%s %s, _%08X @ =%s\n", insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, label_p->name);
-                else if (label_p->branchType == BRANCH_TYPE_BL)
-                    printf("\t%s %s, _%08X @ =sub_%08X\n", insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, value);
-                else // normal label
-                    printf("\t%s %s, _%08X @ =_%08X\n",
-                      insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, value);
+                if (label_p->type != LABEL_THUMB_CODE)
+                {
+                    if (label_p->name != NULL)
+                        printf("\t%s %s, _%08X @ =%s\n", insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, label_p->name);
+                    else if (label_p->branchType == BRANCH_TYPE_BL)
+                        printf("\t%s %s, _%08X @ =sub_%08X\n", insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, value);
+                    else // normal label
+                        printf("\t%s %s, _%08X @ =_%08X\n",
+                          insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, value);
+                    return;
+                }
             }
-            else // raw print
-                printf("\t%s %s, _%08X @ =0x%08X\n", insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, value);
+            printf("\t%s %s, _%08X @ =0x%08X\n", insn->mnemonic, cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), word, value);
         }
         else
         {
@@ -643,15 +646,18 @@ static void print_insn(const cs_insn *insn, uint32_t addr, int mode)
 
                 if (label_p != NULL)
                 {
-                    if (label_p->name != NULL)
-                        printf("\tadd %s, pc, #0x%X @ =%s\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm, label_p->name);
-                    else if (label_p->branchType == BRANCH_TYPE_BL)
-                        printf("\tadd %s, pc, #0x%X @ =sub_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm, word);
-                    else
-                        printf("\tadd %s, pc, #0x%X @ =_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm, word);
+                    if (label_p->type != LABEL_THUMB_CODE)
+                    {
+                        if (label_p->name != NULL)
+                            printf("\tadd %s, pc, #0x%X @ =%s\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm, label_p->name);
+                        else if (label_p->branchType == BRANCH_TYPE_BL)
+                            printf("\tadd %s, pc, #0x%X @ =sub_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm, word);
+                        else
+                            printf("\tadd %s, pc, #0x%X @ =_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm, word);
+                        return;
+                    }
                 }
-                else
-                    printf("\tadd %s, pc, #0x%X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm);
+                printf("\tadd %s, pc, #0x%X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[1].imm);
             }
             // arm adr
             else if (mode == LABEL_ARM_CODE
@@ -681,15 +687,18 @@ static void print_insn(const cs_insn *insn, uint32_t addr, int mode)
                 label_p = lookup_label(word);
                 if (label_p != NULL)
                 {
-                    if (label_p->name != NULL)
-                        printf("\tadd %s, pc, #0x%X @ =%s\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, label_p->name);
-                    else if (label_p->branchType == BRANCH_TYPE_BL)
-                        printf("\tadd %s, pc, #0x%X @ =sub_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, word);
-                    else
-                        printf("\tadd %s, pc, #0x%X @ =_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, word);
+                    if (label_p->type != LABEL_THUMB_CODE)
+                    {
+                        if (label_p->name != NULL)
+                            printf("\tadd %s, pc, #0x%X @ =%s\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, label_p->name);
+                        else if (label_p->branchType == BRANCH_TYPE_BL)
+                            printf("\tadd %s, pc, #0x%X @ =sub_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, word);
+                        else
+                            printf("\tadd %s, pc, #0x%X @ =_%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, word);
+                        return;
+                    }
                 }
-                else // raw print
-                    printf("\tadd %s, pc, #0x%X @ =0x%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, word);
+                printf("\tadd %s, pc, #0x%X @ =0x%08X\n", cs_reg_name(sCapstone, insn->detail->arm.operands[0].reg), insn->detail->arm.operands[2].imm, word);
             }
             else
                 printf("\t%s %s\n", insn->mnemonic, insn->op_str);
@@ -849,15 +858,19 @@ static void print_disassembly(void)
                 label_p = lookup_label(value);
                 if (label_p != NULL)
                 {
-                    if (label_p->name != NULL)
-                        printf("_%08X: .4byte %s\n", addr, label_p->name);
-                    else if (label_p->branchType == BRANCH_TYPE_BL)
-                        printf("_%08X: .4byte sub_%08X\n", addr, value);
-                    else // normal label
-                        printf("_%08X: .4byte _%08X\n", addr, value);
+                    if (label_p->type != LABEL_THUMB_CODE)
+                    {
+                        if (label_p->name != NULL)
+                            printf("_%08X: .4byte %s\n", addr, label_p->name);
+                        else if (label_p->branchType == BRANCH_TYPE_BL)
+                            printf("_%08X: .4byte sub_%08X\n", addr, value);
+                        else // normal label
+                            printf("_%08X: .4byte _%08X\n", addr, value);
+                        addr += 4;
+                        break;
+                    }
                 }
-                else // raw print
-                    printf("_%08X: .4byte 0x%08X\n", addr, value);
+                printf("_%08X: .4byte 0x%08X\n", addr, value);
                 addr += 4;
             }
             break;

--- a/disasm.c
+++ b/disasm.c
@@ -33,6 +33,7 @@ struct Label
 
 struct Label *gLabels = NULL;
 int gLabelsCount = 0;
+static int sLabelBufferCount = 0;
 static csh sCapstone;
 
 const bool gOptionShowAddrComments = false;
@@ -55,9 +56,15 @@ int disasm_add_label(uint32_t addr, uint8_t type, char *name)
     }
 
     i = gLabelsCount++;
-    gLabels = realloc(gLabels, gLabelsCount * sizeof(*gLabels));
-    if (gLabels == NULL)
-        fatal_error("failed to alloc space for labels. ");
+
+    if (gLabelsCount > sLabelBufferCount) // need realloc
+    {
+        sLabelBufferCount = 2 * gLabelsCount;
+        gLabels = realloc(gLabels, sLabelBufferCount * sizeof(*gLabels));
+
+        if (gLabels == NULL)
+            fatal_error("failed to alloc space for labels. ");
+    }
     gLabels[i].addr = addr;
     gLabels[i].type = type;
     if (type == LABEL_ARM_CODE || type == LABEL_THUMB_CODE)

--- a/disasm.c
+++ b/disasm.c
@@ -912,7 +912,8 @@ static void print_disassembly(void)
         nextAddr = gLabels[i].addr;
         assert(addr <= nextAddr);
 
-        print_gap(addr, nextAddr);
+        if (nextAddr <= ROM_LOAD_ADDR + gInputFileBufferSize) // prevent out-of-bound read
+            print_gap(addr, nextAddr);
         addr = nextAddr;
     }
 }

--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@ struct ConfigLabel
 uint8_t *gInputFileBuffer;
 size_t gInputFileBufferSize;
 
-static void fatal_error(const char *fmt, ...)
+void fatal_error(const char *fmt, ...)
 {
     va_list args;
 
@@ -39,6 +39,8 @@ static void read_input_file(const char *fname)
     gInputFileBufferSize = ftell(file);
     fseek(file, 0, SEEK_SET);
     gInputFileBuffer = malloc(gInputFileBufferSize);
+    if (gInputFileBuffer == NULL)
+        fatal_error("failed to alloc file buffer for '%s'", fname);
     if (fread(gInputFileBuffer, 1, gInputFileBufferSize, file) != gInputFileBufferSize)
         fatal_error("failed to read from file '%s'", fname);
     fclose(file);
@@ -83,6 +85,8 @@ static char *dup_string(const char *s)
 {
     char *new = malloc(strlen(s) + 1);
 
+    if (new == NULL)
+        fatal_error("could not alloc space for string '%s'", s);
     strcpy(new, s);
     return new;
 }
@@ -102,6 +106,8 @@ static void read_config(const char *fname)
     size = ftell(file);
     fseek(file, 0, SEEK_SET);
     buffer = malloc(size + 1);
+    if (buffer == NULL)
+        fatal_error("could not alloc buffer for '%s'", fname);
     if (fread(buffer, 1, size, file) != size)
         fatal_error("failed to read from file '%s'", fname);
     buffer[size] = '\0';


### PR DESCRIPTION
- toss names specified in .cfg file when a label is actually considered as not a function. otherwise it will be printed like such (sub_0814F8B8 is the name specified in .cfg file): 
```asm
	ldrb r3, [r2]
	b _0814F892
	.align 2, 0
sub_0814F8B8:
	push {lr}
_0814F8BA:
	ldr r2, [r1, #0x40]
```
- `is_func_return` doesn't actually mean end of function in handwritten area. Now I force code following be considered as function only when mode exchange happens. So that `_0814F3F6` here won't be marked as function.  (Note that, this detection is an addon, so it won't break anything in the area covered by agbcc code. )
```asm
	ldr r2, _0814F458 @ =0x68736D53
	ldr r3, [r0]
	cmp r2, r3
	beq _0814F3F6
	bx lr
_0814F3F6:
	adds r3, #1
	str r3, [r0]
	push {r4, r5, r6, r7, lr}
```
- add a guard field to avoid definite functions being wrongly marked as `BRANCH_TYPE_B`. 
- fix typo when printing comments
- fix potential NULL pointer dereference over malloc/realloc
- better amortized cost for realloc
- sanitize print_gap to prevent out-of-bound read from file buffer